### PR TITLE
Fix: make.sh cannot be executed by proper interpreter

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SELF_DIR="$(dirname $(readlink -f $0))"


### PR DESCRIPTION
On macOS, we often use `brew install bash` to get the latest bash support, which is not located in `/bin/bash`.
However, the macOS bundled bash is too old as not to support `decare -n` in our `make.sh`.
So I changed the shebang and now it works well! 👍 
