### PR TITLE
Implement the clrscr function with the Windows Console API under the Windows platform.

### DIFF
--- a/include/covscript/console/win32_conio.hpp
+++ b/include/covscript/console/win32_conio.hpp
@@ -56,7 +56,26 @@ namespace cs_impl {
 
 		static void clrscr()
 		{
-			system("cls");
+			static CONSOLE_SCREEN_BUFFER_INFO csbi;
+			static DWORD dwWritten;
+			GetConsoleScreenBufferInfo(
+				StdHandle,
+				&csbi);
+			FillConsoleOutputAttribute(
+				StdHandle,
+				csbi.wAttributes,
+				csbi.dwSize.X * csbi.dwSize.Y,
+				{ 0,0 },
+				&dwWritten);
+			FillConsoleOutputCharacterW(
+				StdHandle,
+				L' ',
+				csbi.dwSize.X * csbi.dwSize.Y,
+				{ 0,0 },
+				&dwWritten);
+			SetConsoleCursorPosition(
+				StdHandle,
+				{ 0,0 });
 		}
 
 		static int getch()


### PR DESCRIPTION
Because using the system function for this is just ugly.

Mouri