### PR TITLE
fix: resolve lambda argument handling

### DIFF
--- a/include/covscript/core/core.hpp
+++ b/include/covscript/core/core.hpp
@@ -449,8 +449,9 @@ namespace cs {
 		{
 			mIsMemFn = is_mem_fn;
 			if (!mIsVargs) {
-				std::vector<std::string> args{std::string(reserve)};
-				args.reserve(mArgs.size());
+				std::vector<std::string> args;
+				args.reserve(mArgs.size() + 1);
+				args.emplace_back(reserve);
 				for (auto &name : mArgs) {
 					if (name != reserve)
 						args.emplace_back(std::move(name));
@@ -466,7 +467,7 @@ namespace cs {
 			prefix = mDecl.substr(0, lpos);
 			suffix = mDecl.substr(rpos);
 			if (mArgs.size() > 1 || mIsVargs)
-				mDecl = prefix + "this" + (mIsVargs ? ", ..." : ", ") + mDecl.substr(lpos, rpos - lpos) + suffix;
+				mDecl = prefix + "this, " + mDecl.substr(lpos, rpos - lpos) + suffix;
 			else
 				mDecl = prefix + "this" + suffix;
 #endif

--- a/include/covscript/core/version.hpp
+++ b/include/covscript/core/version.hpp
@@ -42,10 +42,10 @@
  *   the last two digits are different, it will be regarded as a compatible
  *   version.
  */
-#define COVSCRIPT_VERSION_NUM 3, 5, 1, 1
-#define COVSCRIPT_VERSION_STR "3.5.1 Falco peregrinus(Stable) Build 1"
+#define COVSCRIPT_VERSION_NUM 3, 5, 2, 1
+#define COVSCRIPT_VERSION_STR "3.5.2 Falco peregrinus(Stable) Build 1"
 #define COVSCRIPT_STD_VERSION 260702
 #define COVSCRIPT_API_VERSION 260702
-#define COVSCRIPT_ABI_VERSION 260703
+#define COVSCRIPT_ABI_VERSION 260704
 #define CS_VERSION_STR_MIXER(VER) #VER
 #define CS_GET_VERSION_STR(VER) CS_VERSION_STR_MIXER(VER)

--- a/sources/compiler/compiler.cpp
+++ b/sources/compiler/compiler.cpp
@@ -787,14 +787,15 @@ namespace cs {
 						throw compile_error("Invalid lambda expression: unexpected element in the argument list; expected an identifier or a variadic parameter '...<id>'");
 				}
 				bool find_self_ref = find_id_ref(it.right(), "self");
-				if (!is_vargs && find_self_ref) {
-					std::vector<std::string> new_args{"self"};
-					new_args.reserve(args.size());
+				if (find_self_ref) {
+					std::vector<std::string> new_args;
+					new_args.reserve(args.size() + 1);
+					new_args.emplace_back("self");
 					for (auto &name : args) {
 						if (name != "self")
 							new_args.emplace_back(std::move(name));
 						else
-							throw runtime_error("Cannot redefine the implicit 'self' argument of a lambda");
+							throw compile_error("Cannot redefine the implicit 'self' argument of a lambda");
 					}
 					std::swap(new_args, args);
 				}
@@ -1085,8 +1086,9 @@ namespace cs {
 						token_base *oldt = it.data();
 						try {
 							const auto &om = a.const_val<object_method>();
-							vector args{om.object};
-							args.reserve(static_cast<token_arglist *>(rptr)->get_arglist().size());
+							vector args;
+							args.reserve(static_cast<token_arglist *>(rptr)->get_arglist().size() + 1);
+							args.push_back(om.object);
 							for (auto &tree : static_cast<token_arglist *>(rptr)->get_arglist()) {
 								ptr = tree.root().data();
 								if (ptr != nullptr && ptr->get_type() == token_types::expand) {

--- a/sources/instance/runtime.cpp
+++ b/sources/instance/runtime.cpp
@@ -381,7 +381,7 @@ namespace cs {
 	{
 		vector args;
 		token_base *ptr = nullptr;
-		args.reserve(static_cast<token_arglist *>(b)->get_arglist().size());
+		args.reserve(static_cast<token_arglist *>(b)->get_arglist().size() + 1);
 		a.prep_call(args);
 		for (auto &tree : static_cast<token_arglist *>(b)->get_arglist()) {
 			ptr = tree.root().data();

--- a/sources/instance/statement.cpp
+++ b/sources/instance/statement.cpp
@@ -77,13 +77,19 @@ namespace cs {
 			var arg_list = var::make<cs::array>();
 			auto &arr = arg_list.val<cs::array>();
 			std::size_t i = 0;
-			if (_this->mIsMemFn)
+			if (_this->mIsMemFn) {
+				if (args.empty())
+					throw runtime_error("Wrong number of arguments: expected at least 1 for member function, got 0");
 				_this->mContext->instance->storage.add_var_no_return("this", args[i++]);
-			else if (_this->mIsLambda)
+			}
+			else if (_this->mIsLambda && _this->mArgs.size() > 1) {
+				if (args.empty())
+					throw runtime_error("Wrong number of arguments: expected at least 1 for lambda with 'self', got 0");
 				_this->mContext->instance->storage.add_var_no_return("self", args[i++]);
+			}
 			for (; i < args.size(); ++i)
 				arr.push_back(args[i]);
-			_this->mContext->instance->storage.add_var_no_return(_this->mArgs.front().data(), arg_list);
+			_this->mContext->instance->storage.add_var_no_return(_this->mArgs.back().data(), arg_list);
 		}
 		for (auto &ptr : _this->mBody) {
 			try {

--- a/sources/instance/type_ext.cpp
+++ b/sources/instance/type_ext.cpp
@@ -1800,10 +1800,12 @@ namespace cs_impl {
 		{
 			if (func.is_type_of<object_method>()) {
 				const callable::function_type &target = func.const_val<object_method>().callable.const_val<callable>().get_raw_data();
+				std::size_t count = 0;
 				if (target.target_type() == typeid(function_ptr))
-					return target.target<function_ptr>()->fptr->argument_count() - 1;
+					count = target.target<function_ptr>()->fptr->argument_count();
 				else
-					return target.target<cni>()->argument_count() - 1;
+					count = target.target<cni>()->argument_count();
+				return count > 0 ? count - 1 : 0;
 			}
 			else if (func.is_type_of<callable>()) {
 				const callable::function_type &target = func.const_val<callable>().get_raw_data();


### PR DESCRIPTION
## Bug Fixes
 + Fixed variadic lambda swallowing first argument: call_vv unconditionally consumed the first argument as self for all lambdas, causing variadic lambdas without self reference (e.g. [](...args)->args) to lose their first argument. Changed to check mArgs.size() > 1 to determine whether self binding is needed, consistent with the compiler's find_self_ref logic.
 + Enabled self reference in variadic lambdas: Removed the !is_vargs guard in the compiler so that variadic lambdas referencing self (e.g. [](...args)->{self, args...}) correctly have self prepended to the argument list.
 + Fixed variadic parameter name binding: Changed mArgs.front() to mArgs.back() in call_vv to correctly retrieve the variadic parameter name when self is present in mArgs.
 + Fixed unsigned underflow in argument_count: count - 1 on std::size_t underflowed to SIZE_MAX when count == 0 for object_method wrapping a zero-argument function. Added underflow guard.
 + Fixed debugger declaration string for variadic member functions (CS_DEBUGGER only): "this, ......args" corrected to "this, ...args".
## Improvements
 + Added bounds checking in call_vv for empty argument lists to prevent out-of-bounds access for member functions and lambdas with self.
 + Fixed vector::reserve capacity calculations in multiple locations (add_reserve_var, opt_expr, parse_fcall, lambda self argument construction) to avoid unnecessary reallocations.
 + Changed self redefinition error from runtime_error to compile_error for consistency with surrounding compile-time diagnostics.